### PR TITLE
conftest.py: Use basic theme instead of deprecated default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ release = '1'
 exclude_patterns = []
 
 pygments_style = 'sphinx'
-html_theme = 'default'
+html_theme = 'basic'
 """
 
 


### PR DESCRIPTION
This will avoid failure because of a warning with Sphinx 1.3 and fix #3.