### PR TITLE
Ignore "directive u'program-output' is already registered" warnings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ exclude_patterns = []
 
 pygments_style = 'sphinx'
 html_theme = 'basic'
+suppress_warnings = ['app.add_directive']
 """
 
 


### PR DESCRIPTION
With Sphinx 1.4.x, there's this new warning, which makes all tests/test_directive.py fail. Adding the directive makes everything work again.